### PR TITLE
feat: add basic team messaging

### DIFF
--- a/modern-version/public/components/sidebar.html
+++ b/modern-version/public/components/sidebar.html
@@ -26,6 +26,14 @@
     </span>
     Groups
   </a>
+  <a class="sidebar-item" href="/html/messages.html">
+    <span class="sidebar-icon">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V6.375c0-1.035.84-1.875 1.875-1.875h15.75c1.035 0 1.875.84 1.875 1.875v6.375M2.25 12.75l3.9 3.9c.264.264.624.414.998.414h10.704c.374 0 .734-.15.998-.414l3.9-3.9M8.25 9h7.5" />
+      </svg>
+    </span>
+    Messages
+  </a>
   <a class="sidebar-item" href="/html/users.html">
     <span class="sidebar-icon">
       <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">

--- a/modern-version/public/css/messages.css
+++ b/modern-version/public/css/messages.css
@@ -1,0 +1,104 @@
+.chat-container {
+  display: flex;
+  height: calc(100vh - 100px);
+  background: #101622;
+}
+.team-list, .chat-list {
+  width: 200px;
+  background: #101b28;
+  border-right: 1px solid #374151;
+  padding: 10px;
+  overflow-y: auto;
+}
+.chat-list {
+  border-right: 1px solid #374151;
+}
+.list-header {
+  color: #FFD600;
+  font-size: 1.2rem;
+  margin-bottom: 10px;
+}
+.team-list ul, .chat-list ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.team-list li, .chat-list li {
+  padding: 8px;
+  cursor: pointer;
+  border-radius: 4px;
+  color: #fff;
+}
+.team-list li:hover, .chat-list li:hover, .team-list li.active, .chat-list li.active {
+  background: #07111d;
+  color: #FFD600;
+}
+.chat-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #16283c;
+}
+.messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 10px;
+}
+.message {
+  margin-bottom: 8px;
+}
+.message.mine {
+  text-align: right;
+}
+.message .meta {
+  font-size: 0.75rem;
+  color: #9ca3af;
+}
+.message-actions button {
+  margin-left: 4px;
+}
+.message .reactions {
+  font-size: 0.8rem;
+  margin-top: 4px;
+}
+.read-receipt {
+  font-size: 0.7rem;
+  color: #9ca3af;
+}
+.typing-indicator {
+  height: 20px;
+  font-style: italic;
+  color: #FFD600;
+  padding: 4px 10px;
+}
+.message-form {
+  display: flex;
+  border-top: 1px solid #374151;
+}
+.message-form input {
+  flex: 1;
+  padding: 10px;
+  border: none;
+  background: #101622;
+  color: #fff;
+}
+.message-form button {
+  padding: 10px 16px;
+  background: #FFD600;
+  border: none;
+  cursor: pointer;
+}
+.create-chat {
+  margin-top: 8px;
+  width: 100%;
+  background: #07111d;
+  color: #FFD600;
+  border: none;
+  padding: 6px;
+  cursor: pointer;
+  border-radius: 4px;
+}
+.create-chat:hover {
+  background: #FFD600;
+  color: #101b28;
+}

--- a/modern-version/public/html/messages.html
+++ b/modern-version/public/html/messages.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <title>Messages - NEPP</title>
+  <link rel="stylesheet" href="../css/styles.css" />
+  <link rel="stylesheet" href="../css/messages.css" />
+  <link rel="icon" href="../images/logo.png" type="image/png">
+</head>
+<body>
+  <div class="nepp-root">
+    <aside class="sidebar"></aside>
+    <main class="main-content">
+      <h1 class="page-header">Messages</h1>
+      <div class="chat-container">
+        <div class="team-list">
+          <h2 class="list-header">Teams</h2>
+          <ul id="team-list"></ul>
+        </div>
+        <div class="chat-list">
+          <h2 class="list-header">Chats</h2>
+          <ul id="chat-list"></ul>
+        </div>
+        <div class="chat-area">
+          <div id="messages" class="messages"></div>
+          <div id="typing-indicator" class="typing-indicator"></div>
+          <form id="message-form" class="message-form">
+            <input id="message-input" placeholder="Type a message..." autocomplete="off" />
+            <button type="submit">Send</button>
+          </form>
+        </div>
+      </div>
+    </main>
+  </div>
+  <script type="module" src="/config/firebase-config.js"></script>
+  <script type="module" src="/components/sidebar.js"></script>
+  <script type="module" src="/utils/navigation-utils.js"></script>
+  <script type="module" src="../js/messaging.js"></script>
+</body>
+</html>

--- a/modern-version/public/js/messaging.js
+++ b/modern-version/public/js/messaging.js
@@ -1,0 +1,162 @@
+import authManager from '/utils/auth-manager.js';
+import MessagingService from '/services/messaging-service.js';
+
+let currentUser = null;
+let currentTeamId = null;
+let currentChatId = null;
+let unsubscribeMessages = null;
+let unsubscribeTyping = null;
+
+authManager.onAuthStateChanged(async (user) => {
+  if (!user) return;
+  currentUser = user;
+  await loadTeams();
+});
+
+async function loadTeams() {
+  const teams = await MessagingService.getUserTeams(currentUser.uid);
+  const list = document.getElementById('team-list');
+  list.innerHTML = '';
+  teams.forEach(team => {
+    const li = document.createElement('li');
+    li.textContent = team.name;
+    li.addEventListener('click', () => selectTeam(team.id, li));
+    list.appendChild(li);
+  });
+}
+
+async function selectTeam(teamId, element) {
+  currentTeamId = teamId;
+  [...document.querySelectorAll('#team-list li')].forEach(li => li.classList.remove('active'));
+  if (element) element.classList.add('active');
+  const chats = await MessagingService.getTeamChats(teamId);
+  const list = document.getElementById('chat-list');
+  list.innerHTML = '';
+  chats.forEach(chat => {
+    const li = document.createElement('li');
+    li.textContent = chat.name;
+    li.addEventListener('click', () => selectChat(chat.id, li));
+    list.appendChild(li);
+  });
+  const btn = document.createElement('button');
+  btn.textContent = '+ New Chat';
+  btn.classList.add('create-chat');
+  btn.addEventListener('click', async () => {
+    const name = prompt('Chat name');
+    if (!name) return;
+    const membersInput = prompt('Enter member IDs separated by commas or leave blank for all team members');
+    let members;
+    if (membersInput && membersInput.trim()) {
+      members = membersInput.split(',').map(s => s.trim());
+    } else {
+      const team = await MessagingService.getTeam(teamId);
+      members = team.members || [];
+    }
+    await MessagingService.createChat(teamId, { name, members });
+    selectTeam(teamId);
+  });
+  list.appendChild(btn);
+}
+
+function selectChat(chatId, element) {
+  currentChatId = chatId;
+  [...document.querySelectorAll('#chat-list li')].forEach(li => li.classList.remove('active'));
+  if (element) element.classList.add('active');
+  subscribeMessages();
+  subscribeTyping();
+}
+
+function subscribeMessages() {
+  if (unsubscribeMessages) unsubscribeMessages();
+  unsubscribeMessages = MessagingService.listenForMessages(currentTeamId, currentChatId, (msgs) => {
+    const container = document.getElementById('messages');
+    container.innerHTML = '';
+    msgs.forEach(msg => {
+      const div = document.createElement('div');
+      div.classList.add('message');
+      if (msg.senderId === currentUser.uid) div.classList.add('mine');
+      const textDiv = document.createElement('div');
+      textDiv.textContent = msg.text;
+      const metaDiv = document.createElement('div');
+      metaDiv.classList.add('meta');
+      const time = msg.createdAt?.toDate ? msg.createdAt.toDate() : new Date();
+      metaDiv.textContent = `${msg.senderId} • ${time.toLocaleString()}${msg.edited ? ' (edited)' : ''}`;
+      const reactionsDiv = document.createElement('div');
+      reactionsDiv.classList.add('reactions');
+      reactionsDiv.textContent = formatReactions(msg.reactions);
+      const actionsDiv = document.createElement('div');
+      actionsDiv.classList.add('message-actions');
+      const reactBtn = document.createElement('button');
+      reactBtn.textContent = '👍';
+      reactBtn.addEventListener('click', () => MessagingService.toggleReaction(currentTeamId, currentChatId, msg.id, '👍', currentUser.uid));
+      actionsDiv.appendChild(reactBtn);
+      if (msg.senderId === currentUser.uid) {
+        const editBtn = document.createElement('button');
+        editBtn.textContent = 'Edit';
+        editBtn.addEventListener('click', async () => {
+          const newText = prompt('Edit message', msg.text);
+          if (newText !== null) {
+            await MessagingService.editMessage(currentTeamId, currentChatId, msg.id, newText);
+          }
+        });
+        const delBtn = document.createElement('button');
+        delBtn.textContent = 'Delete';
+        delBtn.addEventListener('click', async () => {
+          if (confirm('Delete message?')) {
+            await MessagingService.deleteMessage(currentTeamId, currentChatId, msg.id);
+          }
+        });
+        actionsDiv.appendChild(editBtn);
+        actionsDiv.appendChild(delBtn);
+      }
+      const readDiv = document.createElement('div');
+      readDiv.classList.add('read-receipt');
+      const readCount = msg.readBy ? msg.readBy.length : 0;
+      readDiv.textContent = `Read by ${readCount}`;
+      div.appendChild(textDiv);
+      div.appendChild(metaDiv);
+      div.appendChild(reactionsDiv);
+      div.appendChild(actionsDiv);
+      div.appendChild(readDiv);
+      container.appendChild(div);
+      if (!msg.readBy || !msg.readBy.includes(currentUser.uid)) {
+        MessagingService.markMessageRead(currentTeamId, currentChatId, msg.id, currentUser.uid);
+      }
+    });
+    container.scrollTop = container.scrollHeight;
+  });
+}
+
+function subscribeTyping() {
+  if (unsubscribeTyping) unsubscribeTyping();
+  unsubscribeTyping = MessagingService.listenForTyping(currentTeamId, currentChatId, (users) => {
+    const indicator = document.getElementById('typing-indicator');
+    const others = users.filter(u => u.userId !== currentUser.uid && u.isTyping);
+    if (others.length) {
+      indicator.textContent = `${others.map(u => u.userId).join(', ')} typing...`;
+    } else {
+      indicator.textContent = '';
+    }
+  });
+}
+
+const form = document.getElementById('message-form');
+const input = document.getElementById('message-input');
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const text = input.value.trim();
+  if (!text || !currentTeamId || !currentChatId) return;
+  await MessagingService.sendMessage(currentTeamId, currentChatId, text, currentUser.uid);
+  input.value = '';
+  MessagingService.setTyping(currentTeamId, currentChatId, currentUser.uid, false);
+});
+
+input.addEventListener('input', () => {
+  if (!currentTeamId || !currentChatId) return;
+  MessagingService.setTyping(currentTeamId, currentChatId, currentUser.uid, input.value.length > 0);
+});
+
+function formatReactions(reactions = {}) {
+  return Object.entries(reactions).map(([emoji, users]) => `${emoji} ${users.length}`).join(' ');
+}

--- a/modern-version/public/services/messaging-service.js
+++ b/modern-version/public/services/messaging-service.js
@@ -1,0 +1,134 @@
+import {
+  collection,
+  doc,
+  addDoc,
+  setDoc,
+  getDoc,
+  getDocs,
+  updateDoc,
+  deleteDoc,
+  query,
+  where,
+  orderBy,
+  onSnapshot,
+  serverTimestamp,
+  arrayUnion,
+  arrayRemove
+} from 'https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js';
+import { db } from '/config/firebase-config.js';
+
+class MessagingService {
+  constructor() {
+    this.teamsCollection = 'groups'; // reuse groups as teams
+  }
+
+  async getUserTeams(userId) {
+    const q = query(collection(db, this.teamsCollection), where('members', 'array-contains', userId));
+    const snap = await getDocs(q);
+    return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  }
+
+  async getTeam(teamId) {
+    const teamRef = doc(db, this.teamsCollection, teamId);
+    const teamSnap = await getDoc(teamRef);
+    return { id: teamSnap.id, ...teamSnap.data() };
+  }
+
+  async getTeamChats(teamId) {
+    const chatsCol = collection(db, this.teamsCollection, teamId, 'chats');
+    const q = query(chatsCol, orderBy('createdAt'));
+    const snap = await getDocs(q);
+    return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  }
+
+  async createChat(teamId, { name, members }) {
+    const chatsCol = collection(db, this.teamsCollection, teamId, 'chats');
+    return await addDoc(chatsCol, {
+      name,
+      members,
+      createdAt: serverTimestamp()
+    });
+  }
+
+  async sendMessage(teamId, chatId, text, senderId) {
+    const msgCol = collection(db, this.teamsCollection, teamId, 'chats', chatId, 'messages');
+    await addDoc(msgCol, {
+      senderId,
+      text,
+      createdAt: serverTimestamp(),
+      edited: false,
+      reactions: {},
+      readBy: [senderId]
+    });
+  }
+
+  async editMessage(teamId, chatId, messageId, text) {
+    const msgRef = doc(db, this.teamsCollection, teamId, 'chats', chatId, 'messages', messageId);
+    await updateDoc(msgRef, {
+      text,
+      edited: true,
+      editedAt: serverTimestamp()
+    });
+  }
+
+  async deleteMessage(teamId, chatId, messageId) {
+    const msgRef = doc(db, this.teamsCollection, teamId, 'chats', chatId, 'messages', messageId);
+    await deleteDoc(msgRef);
+  }
+
+  listenForMessages(teamId, chatId, callback) {
+    const msgCol = collection(db, this.teamsCollection, teamId, 'chats', chatId, 'messages');
+    const q = query(msgCol, orderBy('createdAt'));
+    return onSnapshot(q, snap => {
+      const messages = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      callback(messages);
+    });
+  }
+
+  async toggleReaction(teamId, chatId, messageId, emoji, userId) {
+    const msgRef = doc(db, this.teamsCollection, teamId, 'chats', chatId, 'messages', messageId);
+    const snap = await getDoc(msgRef);
+    if (!snap.exists()) return;
+    const data = snap.data();
+    const reactions = data.reactions || {};
+    const current = reactions[emoji] || [];
+    if (current.includes(userId)) {
+      await updateDoc(msgRef, {
+        [`reactions.${emoji}`]: arrayRemove(userId)
+      });
+    } else {
+      await updateDoc(msgRef, {
+        [`reactions.${emoji}`]: arrayUnion(userId)
+      });
+    }
+  }
+
+  async markMessageRead(teamId, chatId, messageId, userId) {
+    const msgRef = doc(db, this.teamsCollection, teamId, 'chats', chatId, 'messages', messageId);
+    await updateDoc(msgRef, {
+      readBy: arrayUnion(userId)
+    });
+  }
+
+  async setTyping(teamId, chatId, userId, isTyping) {
+    const typingRef = doc(db, this.teamsCollection, teamId, 'chats', chatId, 'typing', userId);
+    if (isTyping) {
+      await setDoc(typingRef, {
+        isTyping: true,
+        updatedAt: serverTimestamp()
+      });
+    } else {
+      await deleteDoc(typingRef);
+    }
+  }
+
+  listenForTyping(teamId, chatId, callback) {
+    const typingCol = collection(db, this.teamsCollection, teamId, 'chats', chatId, 'typing');
+    return onSnapshot(typingCol, snap => {
+      const users = snap.docs.map(d => ({ userId: d.id, ...d.data() }));
+      callback(users);
+    });
+  }
+}
+
+export default new MessagingService();


### PR DESCRIPTION
## Summary
- add Messages entry in sidebar and new page for team chats
- implement Firestore-backed messaging service with editing, deletions, reactions, typing indicators, and read receipts
- create client UI to manage teams, chats, and real-time messages

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689647ea9f14832cb0f59100cad535d4